### PR TITLE
allow overriding the ok and cancel buttons

### DIFF
--- a/src/alertSystem/Alert.tsx
+++ b/src/alertSystem/Alert.tsx
@@ -14,11 +14,15 @@ interface AlertProps {
   prompt?: boolean
   confirm?: boolean
   title?: string
+  okLabel?: number
+  cancelLabel?: number
 }
 interface Options {
   className?: string
   title?: string
   duration?: number
+  okLabel?: number
+  cancelLabel?: number
 }
 
 const CustomAlert = (props: AlertProps) => {
@@ -105,14 +109,14 @@ const CustomAlert = (props: AlertProps) => {
             className={[styles.ok, 'alert-buttons_ok'].join(' ')}
             onClick={() => handleClick(true)}
           >
-            OK
+            {props.okLabel ?? 'OK'}
           </button>
           {(props.confirm || props.prompt) && (
             <button
               className={[styles.cancel, 'alert-buttons_cancel'].join(' ')}
               onClick={() => handleClick(false)}
             >
-              Cancel
+              {props.cancelLabel ?? 'Cancel'}
             </button>
           )}
         </div>

--- a/src/alertSystem/Alert.tsx
+++ b/src/alertSystem/Alert.tsx
@@ -14,15 +14,15 @@ interface AlertProps {
   prompt?: boolean
   confirm?: boolean
   title?: string
-  okLabel?: number
-  cancelLabel?: number
+  okLabel?: string
+  cancelLabel?: string
 }
 interface Options {
   className?: string
   title?: string
   duration?: number
-  okLabel?: number
-  cancelLabel?: number
+  okLabel?: string
+  cancelLabel?: string
 }
 
 const CustomAlert = (props: AlertProps) => {


### PR DESCRIPTION
This PR allows you to add an `okLabel` and a `cancelLabel` on the options to be able to change the terms